### PR TITLE
fix 'dict contains fields not in fieldnames' bug and remove duplicate comments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ six==1.16.0
 tabulate==0.8.9
 uritemplate==4.1.1
 urllib3==1.26.9
+iteration_utilities

--- a/utils/comments.py
+++ b/utils/comments.py
@@ -38,6 +38,6 @@ def make_csv(comments, channelID=None):
         filename = f'comments_{today}.csv'
 
     with open(filename, 'w', encoding='utf8', newline='') as f:
-        writer = csv.DictWriter(f, fieldnames=header)
+        writer = csv.DictWriter(f, fieldnames=header, extrasaction='ignore')
         writer.writeheader()
         writer.writerows(comments)

--- a/yt_public.py
+++ b/yt_public.py
@@ -1,6 +1,7 @@
 import os
 from dotenv import load_dotenv
 from googleapiclient.discovery import build
+from iteration_utilities import unique_everseen
 
 from utils.comments import process_comments, make_csv
 
@@ -51,7 +52,9 @@ def comment_threads(channelID, to_csv=False):
         )
         response = request.execute()
         comments_list.extend(process_comments(response['items']))
-    
+
+    comments_list = list(unique_everseen(comments_list))
+
     print(f"Finished fetching comments for {channelID}. {len(comments_list)} comments found.")
     
     if to_csv:
@@ -101,7 +104,7 @@ if __name__ == '__main__':
     channelId = 'UCzIxc8Vg53_ewaRIk3shBug'
 
     # response = search_result("pyscript")
-    response = channel_stats(channelId) 
+    response = channel_stats(channelId)
     # response = comment_threads(pyscriptVidId, to_csv=True)
 
     print(response)


### PR DESCRIPTION
we add the iteration_utilities module to take out the many duplicate comments that appear.
i tried downloading ~6000 comments from a video but then got 650,000 comments (!) and 644,000 of them were duplicates.

this pull request fixes this problem.

we also fix a bug that says 'dict contains fields not in fieldnames'.

thank you for your code